### PR TITLE
Injectable Memoization

### DIFF
--- a/docs/sim/index.rst
+++ b/docs/sim/index.rst
@@ -340,9 +340,21 @@ Use the :py:func:`~urbansim.sim.simulation.add_injectable` function or the
 
 Be default injectable functions are evaluated before injection and the return
 value is passed into other functions. Use ``autocall=False`` to disable this
-behavior and instead inject the wrapped function itself.
-Like tables and columns, injectable functions can have their results
-cached with ``cache=True``.
+behavior and instead inject the function itself.
+Like tables and columns, injectable functions that are automatically evaluated
+can have their results cached with ``cache=True``.
+
+Functions that are not automatically evaluated can also have their results
+cached using the ``memoize=True`` keyword along with ``autocall=False``.
+A memoized injectable will cache results based on the function inputs,
+so this only works if the function inputs are hashable
+(usable as dictionary keys).
+Memoized functions can have their caches cleared manually using their
+``clear_cached`` function attribute.
+The caches of memoized functions are also hooked into the global simulation
+caching system,
+so you can also manage their caches via the ``cache_scope`` keyword argument
+and the :py:func:`~urbansim.sim.simulation.clear_cache` function.
 
 An example of the above injectables in IPython:
 


### PR DESCRIPTION
This enables something like this:

```python
@sim.injectable(autocall=False, memoize=True)
def my_utility_func(x, y, z):
    return x + y + z

@sim.column()
def my_col(another_col, my_utility_func):
    result = my_utility_func(1, 2, 3)
    return another_col * result
```

And if you call `my_utility_func` again with the input of `1, 2, 3` you'll get back the cached result instead of re-doing the calculation.

Memoization requires `autocall=False` and that function inputs always be hashable. The memoization cache follows the same rules as other caching, so you can use `cache_scope=`, `sim.clear_cache`, `sim.disable_cache`, and `sim.enable_cache` as usual.