### PR TITLE
Allow sampling of alternatives during prediction

### DIFF
--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -491,10 +491,15 @@ class MNLDiscreteChoiceModel(DiscreteChoiceModel):
 
         # probabilities are returned from mnl_simulate as a 2d array
         # with choosers along rows and alternatives along columns
+        if self.probability_mode == 'single_chooser':
+            numalts = len(merged)
+        else:
+            numalts = sample_size
+
         probabilities = mnl.mnl_simulate(
             model_design.as_matrix(),
             coeffs,
-            numalts=sample_size, returnprobs=True)
+            numalts=numalts, returnprobs=True)
 
         # want to turn probabilities into a Series with a MultiIndex
         # of chooser IDs and alternative IDs.

--- a/urbansim/models/tests/test_dcm.py
+++ b/urbansim/models/tests/test_dcm.py
@@ -155,6 +155,8 @@ def test_mnl_dcm_repeated_alts(basic_dcm, choosers, alternatives):
     interaction_predict_filters = ['var1 * var2 > 50']
     choice_column = 'thing_id'
 
+    basic_dcm.probability_mode = 'single_chooser'
+    basic_dcm.choice_mode = 'aggregate'
     basic_dcm.interaction_predict_filters = interaction_predict_filters
     basic_dcm.choice_column = choice_column
 

--- a/urbansim/models/tests/test_dcm.py
+++ b/urbansim/models/tests/test_dcm.py
@@ -160,7 +160,7 @@ def test_mnl_dcm(seed, basic_dcm, choosers, alternatives):
 
     pdt.assert_series_equal(
         choices,
-        pd.Series(['h', 'c', 'f'], index=[1, 3, 4]))
+        pd.Series(['b', 'j', 'g'], index=[1, 3, 4]))
 
     # check that we can do a YAML round-trip
     yaml_str = basic_dcm.to_yaml()
@@ -242,6 +242,7 @@ def test_mnl_dcm_yaml(basic_dcm, choosers, alternatives):
 
 def test_mnl_dcm_prob_mode_single(seed, basic_dcm_fit, choosers, alternatives):
     basic_dcm_fit.probability_mode = 'single_chooser'
+    basic_dcm_fit.choice_mode = 'aggregate'
 
     filtered_choosers, filtered_alts = basic_dcm_fit.apply_predict_filters(
         choosers, alternatives)
@@ -251,15 +252,15 @@ def test_mnl_dcm_prob_mode_single(seed, basic_dcm_fit, choosers, alternatives):
     pdt.assert_series_equal(
         probs,
         pd.Series(
-            [0.25666709612190147,
-             0.20225620916965448,
-             0.15937989234214262,
-             0.1255929308043417,
-             0.077988133629030815,
-             0.061455420294827229,
-             0.04842747874412457,
-             0.038161332007195688,
-             0.030071506886781514],
+            [0.33709756,
+             0.23459563,
+             0.16326167,
+             0.11361837,
+             0.05502717,
+             0.03829495,
+             0.02665053,
+             0.01854685,
+             0.01290727],
             index=pd.MultiIndex.from_product(
                 [[1], filtered_alts.index.values],
                 names=['chooser_ids', 'alternative_ids'])))
@@ -271,6 +272,7 @@ def test_mnl_dcm_prob_mode_single(seed, basic_dcm_fit, choosers, alternatives):
 def test_mnl_dcm_prob_mode_single_prediction_sample_size(
         seed, basic_dcm_fit, choosers, alternatives):
     basic_dcm_fit.probability_mode = 'single_chooser'
+    basic_dcm_fit.choice_mode = 'aggregate'
     basic_dcm_fit.prediction_sample_size = 5
 
     filtered_choosers, filtered_alts = basic_dcm_fit.apply_predict_filters(
@@ -281,13 +283,13 @@ def test_mnl_dcm_prob_mode_single_prediction_sample_size(
     pdt.assert_series_equal(
         probs,
         pd.Series(
-            [0.11137766,
-             0.05449957,
-             0.14134044,
-             0.22761617,
-             0.46516616],
+            [0.06805838,
+             0.20192435,
+             0.022939,
+             0.29015121,
+             0.41692705],
             index=pd.MultiIndex.from_product(
-                [[1], ['g', 'j', 'f', 'd', 'a']],
+                [[1], ['f', 'c', 'i', 'b', 'a']],
                 names=['chooser_ids', 'alternative_ids'])))
 
     sprobs = basic_dcm_fit.summed_probabilities(choosers, alternatives)
@@ -321,7 +323,7 @@ def test_mnl_dcm_choice_mode_agg(seed, basic_dcm_fit, choosers, alternatives):
 
     pdt.assert_series_equal(
         choices,
-        pd.Series(['f', 'a', 'd', 'c'], index=[0, 1, 3, 4]))
+        pd.Series(['a', 'c', 'b', 'd'], index=[0, 1, 3, 4]))
 
 
 def test_mnl_dcm_group(seed, grouped_choosers, alternatives):
@@ -367,7 +369,7 @@ def test_mnl_dcm_group(seed, grouped_choosers, alternatives):
 
     pdt.assert_series_equal(
         choices,
-        pd.Series(['c', 'a', 'a', 'g'], index=[0, 3, 1, 4]))
+        pd.Series(['c', 'e', 'c', 'i'], index=[0, 3, 1, 4]))
 
     # check that we don't get the same alt twice if they are removed
     # make sure we're starting from the same random state as the last draw
@@ -377,7 +379,7 @@ def test_mnl_dcm_group(seed, grouped_choosers, alternatives):
 
     pdt.assert_series_equal(
         choices,
-        pd.Series(['c', 'a', 'b', 'g'], index=[0, 3, 1, 4]))
+        pd.Series(['c', 'e', 'd', 'i'], index=[0, 3, 1, 4]))
 
 
 def test_mnl_dcm_segmented_raises():
@@ -441,7 +443,7 @@ def test_mnl_dcm_segmented(seed, grouped_choosers, alternatives):
 
     pdt.assert_series_equal(
         choices,
-        pd.Series(['c', 'a', 'b', 'a', 'j'], index=[0, 2, 3, 1, 4]))
+        pd.Series(['c', 'b', 'i', 'b', 'j'], index=[0, 2, 3, 1, 4]))
 
     # check that we don't get the same alt twice if they are removed
     # make sure we're starting from the same random state as the last draw
@@ -451,7 +453,7 @@ def test_mnl_dcm_segmented(seed, grouped_choosers, alternatives):
 
     pdt.assert_series_equal(
         choices,
-        pd.Series(['c', 'a', 'b', 'd', 'j'], index=[0, 2, 3, 1, 4]))
+        pd.Series(['c', 'b', 'i', 'a', 'j'], index=[0, 2, 3, 1, 4]))
 
 
 def test_mnl_dcm_segmented_yaml(grouped_choosers, alternatives):

--- a/urbansim/models/tests/test_dcm.py
+++ b/urbansim/models/tests/test_dcm.py
@@ -110,6 +110,26 @@ def test_unit_choice_none_available(choosers, alternatives):
     assert choices.isnull().all()
 
 
+def test_mnl_dcm_prob_choice_mode_compat(basic_dcm):
+    with pytest.raises(ValueError):
+        dcm.MNLDiscreteChoiceModel(
+            basic_dcm.model_expression, basic_dcm.sample_size,
+            probability_mode='single_chooser', choice_mode='individual')
+
+    with pytest.raises(ValueError):
+        dcm.MNLDiscreteChoiceModel(
+            basic_dcm.model_expression, basic_dcm.sample_size,
+            probability_mode='full_product', choice_mode='aggregate')
+
+
+def test_mnl_dcm_prob_mode_interaction_compat(basic_dcm):
+    with pytest.raises(ValueError):
+        dcm.MNLDiscreteChoiceModel(
+            basic_dcm.model_expression, basic_dcm.sample_size,
+            probability_mode='full_product', choice_mode='individual',
+            interaction_predict_filters=['var1 > 9000'])
+
+
 def test_mnl_dcm(seed, basic_dcm, choosers, alternatives):
     assert basic_dcm.choosers_columns_used() == ['var1']
     assert set(basic_dcm.alts_columns_used()) == {'var2', 'var3'}
@@ -365,6 +385,26 @@ def test_mnl_dcm_segmented_raises():
 
     with pytest.raises(ValueError):
         group.add_segment('x')
+
+
+def test_mnl_dcm_segmented_prob_choice_mode_compat():
+    with pytest.raises(ValueError):
+        dcm.SegmentedMNLDiscreteChoiceModel(
+            'group', 10,
+            probability_mode='single_chooser', choice_mode='individual')
+
+    with pytest.raises(ValueError):
+        dcm.SegmentedMNLDiscreteChoiceModel(
+            'group', 10,
+            probability_mode='full_product', choice_mode='aggregate')
+
+
+def test_mnl_dcm_segmented_prob_mode_interaction_compat():
+    with pytest.raises(ValueError):
+        dcm.SegmentedMNLDiscreteChoiceModel(
+            'group', 10,
+            probability_mode='full_product', choice_mode='individual',
+            interaction_predict_filters=['var1 > 9000'])
 
 
 def test_mnl_dcm_segmented(seed, grouped_choosers, alternatives):

--- a/urbansim/urbanchoice/interaction.py
+++ b/urbansim/urbanchoice/interaction.py
@@ -54,7 +54,10 @@ def mnl_interaction_dataset(choosers, alternatives, SAMPLE_SIZE,
     # because a) why not? and b) testing.
     alts_idx = np.arange(len(alternatives))
     if SAMPLE_SIZE < numalts:
-        sample = np.random.choice(alts_idx, SAMPLE_SIZE * numchoosers)
+        sample = np.concatenate(tuple(
+            np.random.choice(alts_idx, SAMPLE_SIZE, replace=False)
+            for _ in range(numchoosers)))
+
         if chosenalts is not None:
             # replace the first row for each chooser with
             # the currently chosen alternative.

--- a/urbansim/utils/yamlio.py
+++ b/urbansim/utils/yamlio.py
@@ -79,6 +79,7 @@ def ordered_yaml(cfg):
              'alts_fit_filters', 'alts_predict_filters',
              'interaction_predict_filters',
              'choice_column', 'sample_size', 'estimation_sample_size',
+             'prediction_sample_size',
              'model_expression', 'ytransform', 'min_segment_size',
              'default_config', 'models', 'coefficients', 'fitted']
 


### PR DESCRIPTION
It's kind of limited sampling, not something you could use
during a location choice model. Alternatives may show up as
available for more than one chooser and alternatives may show up
more than once for a single chooser.