### PR TITLE
Make sure summed probs indexes match alts

### DIFF
--- a/urbansim/models/dcm.py
+++ b/urbansim/models/dcm.py
@@ -585,7 +585,9 @@ class MNLDiscreteChoiceModel(DiscreteChoiceModel):
 
         # groupby the the alternatives ID and sum
         if self.probability_mode == 'single_chooser':
-            return normalize(probs) * len(choosers)
+            return (
+                normalize(probs) * len(choosers)
+                ).reset_index(level=0, drop=True)
         elif self.probability_mode == 'full_product':
             return probs.groupby(level=0).apply(normalize)\
                 .groupby(level=1).sum()

--- a/urbansim/models/tests/test_dcm.py
+++ b/urbansim/models/tests/test_dcm.py
@@ -154,6 +154,7 @@ def test_mnl_dcm(seed, basic_dcm, choosers, alternatives):
 
     sprobs = basic_dcm.summed_probabilities(choosers, alternatives)
     assert len(sprobs) == len(filtered_alts)
+    pdt.assert_index_equal(sprobs.index, filtered_alts.index)
     npt.assert_allclose(sprobs.sum(), len(filtered_choosers))
 
     choices = basic_dcm.predict(choosers.iloc[1:], alternatives)
@@ -266,6 +267,7 @@ def test_mnl_dcm_prob_mode_single(seed, basic_dcm_fit, choosers, alternatives):
                 names=['chooser_ids', 'alternative_ids'])))
 
     sprobs = basic_dcm_fit.summed_probabilities(choosers, alternatives)
+    pdt.assert_index_equal(sprobs.index, filtered_alts.index)
     npt.assert_allclose(sprobs.sum(), len(filtered_choosers))
 
 
@@ -293,6 +295,8 @@ def test_mnl_dcm_prob_mode_single_prediction_sample_size(
                 names=['chooser_ids', 'alternative_ids'])))
 
     sprobs = basic_dcm_fit.summed_probabilities(choosers, alternatives)
+    pdt.assert_index_equal(
+        sprobs.index, pd.Index(['j', 'b', 'g', 'h', 'd']))
     npt.assert_allclose(sprobs.sum(), len(filtered_choosers))
 
 
@@ -309,6 +313,7 @@ def test_mnl_dcm_prob_mode_full_prediction_sample_size(
     npt.assert_allclose(probs.sum(), len(filtered_choosers) - 1)
 
     sprobs = basic_dcm_fit.summed_probabilities(choosers, alternatives)
+    pdt.assert_index_equal(sprobs.index, filtered_alts.index)
     npt.assert_allclose(sprobs.sum(), len(filtered_choosers))
 
 
@@ -363,6 +368,7 @@ def test_mnl_dcm_group(seed, grouped_choosers, alternatives):
 
     sprobs = group.summed_probabilities(grouped_choosers, alternatives)
     assert len(sprobs) == len(filtered_alts)
+    pdt.assert_index_equal(sprobs.index, filtered_alts.index)
 
     choice_state = np.random.get_state()
     choices = group.predict(grouped_choosers, alternatives)
@@ -437,6 +443,7 @@ def test_mnl_dcm_segmented(seed, grouped_choosers, alternatives):
 
     sprobs = group.summed_probabilities(grouped_choosers, alternatives)
     assert len(sprobs) == len(alternatives)
+    pdt.assert_index_equal(sprobs.index, alternatives.index)
 
     choice_state = np.random.get_state()
     choices = group.predict(grouped_choosers, alternatives)


### PR DESCRIPTION
We weren't removing the choosers layer of the summed probs MultiIndex when `probability_mode='single_chooser'`, so the summed probs in that mode would have a weird MultiIndex.

Fixed it to drop the chooser ID layer of the summed probs index when in "single chooser" mode.